### PR TITLE
Update einf_gesellschaftsrecht.md

### DIFF
--- a/docs/230925/einf_gesellschaftsrecht.md
+++ b/docs/230925/einf_gesellschaftsrecht.md
@@ -1745,7 +1745,7 @@ dieser Stelle nicht besprochen.
 ## Kollektivgesellschaft
 
 Die Kollektivgesellschaft (Art. 552 ff. OR) ist die idealtypische
-Personengesellschaft und ist daher ganz rechts in den beiden sich
+Personengesellschaft und ist daher ganz links in den beiden sich
 überlappenden Dreiecken zu verorten.
 
 Die Kollektivgesellschaft verfügt über mindestens zwei Gesellschafter.


### PR DESCRIPTION
Logikfehler, Text stimmte nicht mit der Grafik überein.

Ganz rechts in der Grafik sind die Kapitalgesellschaften und die Kollektivgesellschaft neigt stark zur Personengesellschaft und ist somit links zu verorten.